### PR TITLE
Visitor cart remove

### DIFF
--- a/app/controllers/accessories_controller.rb
+++ b/app/controllers/accessories_controller.rb
@@ -4,4 +4,8 @@ class AccessoriesController < ApplicationController
     @accessories = Accessory.all
   end
 
+  def show
+    @accessory = Accessory.find(params[:id])
+  end
+
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -2,10 +2,10 @@ class CartsController < ApplicationController
   include ActionView::Helpers::TextHelper
 
   def show
-    accessory_ids = @cart.contents.keys
+    accessory_ids = @cart.contents.select {|k, v| v > 0}.keys
     @accessories = accessory_ids.map  do |accessory_id|
       Accessory.find(accessory_id)
-    end 
+    end
   end
 
   def create
@@ -16,6 +16,14 @@ class CartsController < ApplicationController
     flash[:notice] = "You now have #{pluralize(session[:cart][accessory.id.to_s], accessory.name)} in your cart."
 
     redirect_to bike_shop_path
+  end
+
+  def remove
+    accessory = Accessory.find(params[:accessory_id])
+    @cart.remove_accessory(params[:accessory_id])
+    flash[:notice] = "Successfully removed #{view_context.link_to(accessory.name, accessory_path(accessory))} from your cart.".html_safe
+
+    redirect_to '/cart'
   end
 
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,6 +1,13 @@
 class CartsController < ApplicationController
   include ActionView::Helpers::TextHelper
 
+  def show
+    accessory_ids = @cart.contents.keys
+    @accessories = accessory_ids.map  do |accessory_id|
+      Accessory.find(accessory_id)
+    end 
+  end
+
   def create
     accessory = Accessory.find(params[:accessory_id])
 

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -13,6 +13,10 @@ class Cart
     @contents[accessory_id.to_s] += 1
   end
 
+  def remove_accessory(accessory_id)
+    @contents[accessory_id.to_s] -= 1
+  end
+
   def count_of(accessory_id)
     @contents[accessory_id.to_s]
   end

--- a/app/views/accessories/show.html.erb
+++ b/app/views/accessories/show.html.erb
@@ -1,0 +1,4 @@
+<h3><%= @accessory.name %></h3>
+
+<p><%= @accessory.price %></p>
+<p><%= @accessory.description %></p>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -1,0 +1,8 @@
+<h3>Accessories in your cart</h3>
+
+<div class="show-accessories">
+  <% @accessories.each do |accessory| %>
+    <%= accessory.name %>
+    <%= accessory.price %>
+  <% end %>
+</div>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -4,5 +4,6 @@
   <% @accessories.each do |accessory| %>
     <%= accessory.name %>
     <%= accessory.price %>
+    <%= button_to "remove", carts_path(accessory_id: accessory.id), method: :delete %>
   <% end %>
 </div>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -4,6 +4,6 @@
   <% @accessories.each do |accessory| %>
     <%= accessory.name %>
     <%= accessory.price %>
-    <%= button_to "remove", carts_path(accessory_id: accessory.id), method: :delete %>
+    <%= button_to "remove", remove_accessory_path(accessory_id: accessory.id), method: :patch %>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   <body>
     <div class="flash" >
       <% flash.each do |name, msg| %>
-        <%= content_tag :div, msg, class: name %>
+        <%= content_tag :div, msg.html_safe, class: name %>
       <% end %>
     </div>
     <header class="site-banner">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get "/dashboard", to: "users#show"
 
   resources :carts, only: [:create]
+  get "/cart", to: "carts#show"
 
   get "/bike-shop", to: "accessories#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,9 @@ Rails.application.routes.draw do
 
   resources :carts, only: [:create]
   get "/cart", to: "carts#show"
+  patch "/remove-accessory", to: "carts#remove"
 
+  resources :accessories, only: [:show]
   get "/bike-shop", to: "accessories#index"
 
   get "/login", to: "sessions#new"

--- a/spec/factories/accessories.rb
+++ b/spec/factories/accessories.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :accessory do
+    sequence(:name) { |n| "name#{n}" }
+    sequence(:description) { |n| "description#{n}"}
+    sequence(:price) { |n| 100 + n}
+  end
+end

--- a/spec/features/cart/visitor_can_view_items_in_cart_spec.rb
+++ b/spec/features/cart/visitor_can_view_items_in_cart_spec.rb
@@ -28,8 +28,11 @@ describe "visitor can view items in cart" do
 
       expect(current_path). to eq('/cart')
       expect(page).to have_content("Cart: 0")
-      expect(page).to_not have_content(accessory_1.name)
+      expect(page).to have_content("Successfully removed")
       expect(page).to_not have_content(accessory_1.price)
+      click_on("#{accessory_1.name}")
+
+      expect(current_path).to eq(accessory_path(accessory_1))
     end
   end
 end

--- a/spec/features/cart/visitor_can_view_items_in_cart_spec.rb
+++ b/spec/features/cart/visitor_can_view_items_in_cart_spec.rb
@@ -4,11 +4,10 @@ describe "visitor can view items in cart" do
   describe "visits /cart" do
     it "shows all items in cart" do
       accessory_1 = create(:accessory)
-      accessory_2 = create(:accessory)
 
       visit bike_shop_path
 
-      click_on("Add to cart", matches: :first)
+      click_on("Add to cart")
 
       visit cart_path
 

--- a/spec/features/cart/visitor_can_view_items_in_cart_spec.rb
+++ b/spec/features/cart/visitor_can_view_items_in_cart_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe "visitor can view items in cart" do
+  describe "visits /cart" do
+    it "shows all items in cart" do
+      accessory_1 = create(:accessory)
+      accessory_2 = create(:accessory)
+
+      visit bike_shop_path
+
+      click_on("Add to cart", matches: :first)
+
+      visit cart_path
+
+      expect(page).to have_content(accessory_1.name)
+      expect(page).to have_content(accessory_1.price)
+      expect(page).to have_content("remove")
+    end
+  end
+end

--- a/spec/features/cart/visitor_can_view_items_in_cart_spec.rb
+++ b/spec/features/cart/visitor_can_view_items_in_cart_spec.rb
@@ -11,9 +11,10 @@ describe "visitor can view items in cart" do
 
       visit cart_path
 
+      expect(current_path).to eq('/cart')
       expect(page).to have_content(accessory_1.name)
       expect(page).to have_content(accessory_1.price)
-      expect(page).to have_content("remove")
+      expect(page).to have_button("remove")
     end
   end
 end

--- a/spec/features/cart/visitor_can_view_items_in_cart_spec.rb
+++ b/spec/features/cart/visitor_can_view_items_in_cart_spec.rb
@@ -1,20 +1,35 @@
 require 'rails_helper'
 
 describe "visitor can view items in cart" do
-  describe "visits /cart" do
+  context "visits /cart" do
     it "shows all items in cart" do
       accessory_1 = create(:accessory)
 
       visit bike_shop_path
-
       click_on("Add to cart")
-
       visit cart_path
 
       expect(current_path).to eq('/cart')
+      expect(page).to have_content("Cart: 1")
       expect(page).to have_content(accessory_1.name)
       expect(page).to have_content(accessory_1.price)
       expect(page).to have_button("remove")
+    end
+  end
+
+  context "can remove items from cart" do
+    it "clicks on remove button and receives message" do
+      accessory_1 = create(:accessory)
+
+      visit bike_shop_path
+      click_on("Add to cart")
+      visit cart_path
+      click_on("remove")
+
+      expect(current_path). to eq('/cart')
+      expect(page).to have_content("Cart: 0")
+      expect(page).to_not have_content(accessory_1.name)
+      expect(page).to_not have_content(accessory_1.price)
     end
   end
 end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -17,11 +17,21 @@ describe Cart, type: :model do
       expect(cart.contents).to eq({"1" => 2, "2" => 4})
     end
 
+    it "#remove_accessory changes content count" do
+      cart = Cart.new({"1" => 1, "2" => 3})
+
+      cart.remove_accessory(1)
+      cart.remove_accessory(2)
+
+      expect(cart.contents).to eq({"1" => 0, "2" => 2})
+    end
+
     it "#count_of returns count of specific accessory" do
       cart = Cart.new({"1" => 1, "2" => 3})
 
       expect(cart.count_of(1)).to eq(1)
       expect(cart.count_of(2)).to eq(3)
     end
+
   end
 end


### PR DESCRIPTION
Description of the changes proposed in pull request:
+ visitor can view items in cart spec - includes visitor can remove item from carts
  - includes flash message with link to removed station
  - created accessories show
  - add instance method #remove_accessory to cart model

Merge Conflicts? List details if present.


Team Member To Approve:
@kylesallette @andymond 
