### PR TITLE
Admin create accessory

### DIFF
--- a/app/controllers/accessories_controller.rb
+++ b/app/controllers/accessories_controller.rb
@@ -8,4 +8,28 @@ class AccessoriesController < ApplicationController
     @accessory = Accessory.find(params[:id])
   end
 
+  def new
+    if current_admin?
+      @accessory = Accessory.new
+    else
+      redirect_to bike_shop_path
+    end
+  end
+
+  def create
+    @accessory = Accessory.new(accessory_params)
+    if @accessory.save
+      redirect_to admin_bike_shop_path
+    else
+      render :new
+    end
+    #need to gate from non-admin?
+  end
+
+  private
+
+  def accessory_params
+    params.require(:accessory).permit(:name, :description, :price, :image_path)
+  end
+
 end

--- a/app/models/accessory.rb
+++ b/app/models/accessory.rb
@@ -1,5 +1,6 @@
 class Accessory < ApplicationRecord
   validates_presence_of :name, :description, :price
+  validates_uniqueness_of :name
 
   has_many :order_accessories
   has_many :orders, through: :order_accessories

--- a/app/views/accessories/new.html.erb
+++ b/app/views/accessories/new.html.erb
@@ -1,0 +1,16 @@
+<h3>Create a new accessory</h3>
+
+<%= form_for(@accessory) do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+
+  <%= f.label :description %>
+  <%= f.text_area :description %>
+
+  <%= f.label :price %>
+  <%= f.number_field :price %>
+
+  <%= f.hidden_field :image_path, :value => 'bike.png' %>
+
+  <%= f.submit %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,8 +20,9 @@ Rails.application.routes.draw do
   patch "/decrease-quantity", to: "carts#decrease"
   patch "/remove-accessory", to: "carts#remove"
 
-  resources :accessories, only: [:show]
+  resources :accessories, only: [:show, :create]
   get "/bike-shop", to: "accessories#index"
+  get "/bike-shop/new", to: "accessories#new"
 
   resources :orders, only: [:create, :show]
 

--- a/spec/features/accessories/admin_can_create_accessory_spec.rb
+++ b/spec/features/accessories/admin_can_create_accessory_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe "admin can create an accessory" do
+  context "visit /bike-shop/new" do
+    it "fill out all information and creates new accessory" do
+      bob = User.create(username: "bob",
+                        password: "test",
+                        email:"bob@gmail.com",
+                        role: 1)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(bob)
+
+      visit new_accessory_path
+      fill_in('Name', with: 'Gloves')
+      fill_in('Description', with: 'Keep your hands warm!')
+      fill_in('Price', with: 1234)
+      click_on('Create Accssory')
+
+      expect(current_path).to eq(admin_bike_shop_path)
+      expect(page).to have_content(Accessory.last.name)
+      expect(page).to have_content(Accessory.last.description)
+      expect(page).to have_content(Accessory.last.price)
+    end
+  end
+end

--- a/spec/features/accessories/admin_can_create_accessory_spec.rb
+++ b/spec/features/accessories/admin_can_create_accessory_spec.rb
@@ -21,5 +21,57 @@ describe "admin can create an accessory" do
       expect(page).to have_content(Accessory.last.description)
       expect(page).to have_content(Accessory.last.price)
     end
+
+    it "cannot create accessory with duplicate name" do
+      bob = User.create(username: "bob",
+                        password: "test",
+                        email:"bob@gmail.com",
+                        role: 1)
+      create(:accessory, name: "helmet")
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(bob)
+
+      visit bike_shop_new_path
+      fill_in('Name', with: 'helmet')
+      fill_in('Description', with: 'Keep your hands warm!')
+      fill_in('Price', with: 1234)
+      click_on('Create Accessory')
+
+      expect(current_path).to eq(accessories_path)
+      expect(Accessory.count).to eq(1)
+    end
+
+    it "cannot create accessory without name, descr, or price" do
+      bob = User.create(username: "bob",
+                        password: "test",
+                        email:"bob@gmail.com",
+                        role: 1)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(bob)
+
+      visit bike_shop_new_path
+      fill_in('Description', with: 'Keep your hands warm!')
+      fill_in('Price', with: 1234)
+      click_on('Create Accessory')
+
+      expect(current_path).to eq(accessories_path)
+      expect(Accessory.count).to eq(0)
+
+      fill_in('Name', with: 'helmet')
+      fill_in('Description', with: '')
+      fill_in('Price', with: 1234)
+      click_on('Create Accessory')
+
+      expect(current_path).to eq(accessories_path)
+      expect(Accessory.count).to eq(0)
+
+      fill_in('Name', with: 'helmet')
+      fill_in('Description', with: 'Keep your hands warm!')
+      fill_in('Price', with: '')
+      click_on('Create Accessory')
+
+      expect(current_path).to eq(accessories_path)
+      expect(Accessory.count).to eq(0)
+    end
   end
 end

--- a/spec/features/accessories/admin_can_create_accessory_spec.rb
+++ b/spec/features/accessories/admin_can_create_accessory_spec.rb
@@ -10,11 +10,11 @@ describe "admin can create an accessory" do
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(bob)
 
-      visit new_accessory_path
+      visit bike_shop_new_path
       fill_in('Name', with: 'Gloves')
       fill_in('Description', with: 'Keep your hands warm!')
       fill_in('Price', with: 1234)
-      click_on('Create Accssory')
+      click_on('Create Accessory')
 
       expect(current_path).to eq(admin_bike_shop_path)
       expect(page).to have_content(Accessory.last.name)

--- a/spec/models/accessory_spec.rb
+++ b/spec/models/accessory_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 describe Accessory, type: :model do
-  describe "validatoins" do
+  describe "validations" do
     it {should validate_presence_of(:name)}
+    it {should validate_uniqueness_of(:name)}
     it {should validate_presence_of(:description)}
     it {should validate_presence_of(:price)}
   end


### PR DESCRIPTION
Description of the changes proposed in pull request:
+ admin can create new accessory (defaults to 'bike.png' image with hidden field)
+ added uniqueness to accessory name (no duplicates)
  - accessory new action is gated from non admin - should create be as well?

Merge Conflicts? List details if present.
+ no

Team Member To Approve:
@andymond @kylesallette 